### PR TITLE
add mysql-connector-c

### DIFF
--- a/var/spack/repos/builtin/packages/mysql-connector-c/fix-cmake.patch
+++ b/var/spack/repos/builtin/packages/mysql-connector-c/fix-cmake.patch
@@ -1,0 +1,12 @@
+--- a/cmake/install_macros.cmake
++++ /dev/null
+@@ -362,8 +362,8 @@
+         CONFIGURATIONS Release RelWithDebInfo
+         COMPONENT ${ARG_COMPONENT}
+         OPTIONAL)
+-    ENDIF()
+   ENDFOREACH()
++  ENDIF()
+ 
+ ENDFUNCTION()
+ 

--- a/var/spack/repos/builtin/packages/mysql-connector-c/package.py
+++ b/var/spack/repos/builtin/packages/mysql-connector-c/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MysqlConnectorC(CMakePackage):
+    """MySQL Connector/C, the C interface for communicating with MySQL servers.
+
+    Connector/C is a client library that implements the C API for client/server
+    communication. It is a standalone replacement for the MySQL client library
+    shipped with MySQL Server distributions."""
+
+    homepage = "https://dev.mysql.com/downloads/connector/c/"
+    url = "https://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.11-src.tar.gz"
+
+    depends_on("cmake")
+
+    patch("fix-cmake.patch", when="@6.1.11")
+
+    version("6.1.11", sha256="c8664851487200162b38b6f3c8db69850bd4f0e4c5ff5a6d161dbfb5cb76b6c4")


### PR DESCRIPTION
Adds mysql-connector-c recipe recipe. This is an adaptation of https://github.com/conda-forge/mysql-connector-c-feedstock