### PR TITLE
GHA changes to use our own fork of spack and our Harbor CR

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # @v1
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to Seqera Labs' Container Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # @v1
         with:
           registry: cr.seqera.io/spack

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,9 +3,9 @@ name: Containers
 on:
   # This Workflow can be triggered manually
   workflow_dispatch:
-  # Build new Spack develop containers nightly.
-  schedule:
-    - cron: '34 0 * * *'
+  # # Build new Spack develop containers nightly.
+  # schedule:
+  #   - cron: '34 0 * * *'
   # Run on pull requests that modify this file
   pull_request:
     branches:
@@ -39,21 +39,9 @@ jobs:
         # 0: Container name (e.g. ubuntu-bionic)
         # 1: Platforms to build for
         # 2: Base image (e.g. ubuntu:18.04)
-        dockerfile: [[amazon-linux, 'linux/amd64,linux/arm64', 'amazonlinux:2'],
-                     [centos7, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:7'],
-                     [centos-stream, 'linux/amd64,linux/arm64,linux/ppc64le', 'centos:stream'],
-                     [leap15, 'linux/amd64,linux/arm64,linux/ppc64le', 'opensuse/leap:15'],
-                     [ubuntu-bionic, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:18.04'],
-                     [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
-                     [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04'],
-                     [almalinux8, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:8'],
-                     [almalinux9, 'linux/amd64,linux/arm64,linux/ppc64le', 'almalinux:9'],
-                     [rockylinux8, 'linux/amd64,linux/arm64', 'rockylinux:8'],
-                     [rockylinux9, 'linux/amd64,linux/arm64', 'rockylinux:9'],
-                     [fedora37, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:37'],
-                     [fedora38, 'linux/amd64,linux/arm64,linux/ppc64le', 'fedora:38']]
+        dockerfile: [[ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04']]
     name: Build ${{ matrix.dockerfile[0] }}
-    if: github.repository == 'spack/spack'
+    if: github.repository == 'seqeralabs/spack'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # @v2
@@ -100,16 +88,9 @@ jobs:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # @v1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # @v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: cr.seqera.io/spack
+          username: ${{ secrets.SEQERA_HARBOR_SPACK_USERNAME }}
+          password: ${{ secrets.SEQERA_HARBOR_SPACK_PASSWORD }}
 
       - name: Build & Deploy ${{ matrix.dockerfile[0] }}
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # @v2
@@ -120,7 +101,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            spack/${{ env.container }}
-            spack/${{ env.versioned }}
-            ghcr.io/spack/${{ env.container }}
-            ghcr.io/spack/${{ env.versioned }}
+            cr.seqera.io/spack/${{ env.container }}
+            cr.seqera.io/spack/${{ env.versioned }}

--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -112,7 +112,7 @@ def _stage_base_images(images_config):
 def _spack_checkout_config(images_config):
     spack_info = images_config["spack"]
 
-    url = "https://github.com/spack/spack.git"
+    url = "https://github.com/seqeralabs/spack.git"
     ref = "develop"
     resolve_sha, verify = False, False
 


### PR DESCRIPTION
Disabled cron for now, since we don't expect to need to rebuild the base images nightly.
For now we only build ubuntu-jammy, but more base images could be built in the future.
Push to our Harbor, since it's easier than setting up the token retrieval action + authenticating to ECR.