### PR TITLE
Make the build pipeline create container with timestamp too

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -51,8 +51,10 @@ jobs:
       - name: Set Container Tag Normal (Nightly)
         run: |
           container="${{ matrix.dockerfile[0] }}:latest"
-          echo "container=${container}" >> $GITHUB_ENV
-          echo "versioned=${container}" >> $GITHUB_ENV
+          timestamp="${{ matrix.dockerfile[0] }}:$(TZ=UTC date '+%Y-%m-%d-%H-%M-%SZ')"
+          echo "container=${container}"   >> $GITHUB_ENV
+          echo "versioned=${container}"   >> $GITHUB_ENV
+          echo "timestamped=${timestamp}" >> $GITHUB_ENV
 
         # On a new release create a container with the same tag as the release.
       - name: Set Container Tag on Release
@@ -120,3 +122,4 @@ jobs:
           tags: |
             195996028523.dkr.ecr.eu-west-1.amazonaws.com/${{ steps.baseURL.outputs.BASE_REPO_URL }}/${{ env.container }}
             195996028523.dkr.ecr.eu-west-1.amazonaws.com/${{ steps.baseURL.outputs.BASE_REPO_URL }}/${{ env.versioned }}
+            195996028523.dkr.ecr.eu-west-1.amazonaws.com/${{ steps.baseURL.outputs.BASE_REPO_URL }}/${{ env.timestamped }}


### PR DESCRIPTION
Currently the [spack build pipeline](https://github.com/seqeralabs/spack/blob/0965ed69185661727a56badf02ff680fbd9d948c/.github/workflows/build-containers.yml) that we edited last month to push to our ECR repo is only pushing images using the `latest` tag.
The pipeline has the option to tag the containers with the release name when a new release is cut, but we probably won't cut new releases very often.
The spack upstream people do that, and that's how their v0.20.* images were created, see https://hub.docker.com/r/spack/ubuntu-jammy/tags
The `latest` image is overwritten daily.

Since we don't build containers daily because we don't need to test spack itself (that's why the cron job line was disabled), and we build them when somebody in seqera hits the build button, this PR aims at adding a more stable tag to the images, using a timestamp, otherwise apart from the digest there's no other way to pinpoint a container image.

Let me know if this makes sense Pablo.