### PR TITLE
Disable automerge from spack/spack, broken due to conflicts

### DIFF
--- a/.github/workflows/automerge-spack-upstream.yml
+++ b/.github/workflows/automerge-spack-upstream.yml
@@ -1,8 +1,8 @@
 name: Automatic spack/spack merge into seqeralabs/spack
 on:
-  schedule:
-    # scheduled for 00:00 every day
-    - cron: '0 0 * * *'
+  # schedule:
+  #   # scheduled for 00:00 every day
+  #   - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       upstream-repo:


### PR DESCRIPTION
This GHA has been firing for months, but it always fails because there are conflicts (we changed files that upstream spack also changed).
Moreover this is not required anymore, since we're moving away from rebuilding our own spack base image for wave, see full discussion at: https://github.com/seqeralabs/devops-backlog/issues/269